### PR TITLE
fixed issue #5

### DIFF
--- a/dirlididi-wrapper.py
+++ b/dirlididi-wrapper.py
@@ -40,7 +40,7 @@ def setup(user_token):
 	
 	print('Download concluído. Configurando ambiente...')
 
-	if os.environ['DIRLIDIDI_HOME'] != None:
+	if os.environ.get('DIRLIDIDI_HOME') != None:
 		with open(USER_HOME + '/.bashrc', 'a') as bashrc:
 			bashrc.write('\nexport DIRLIDIDI_HOME=' + DIRLIDIDI_HOME)
 			bashrc.write('\nexport DIRLIDIDI_USER_TOKEN=' + user_token)


### PR DESCRIPTION
O acesso ao dict com [] retorna um KeyError se não encontrar a chave.
Através do método get() é retornado um erro caso não exista a chave.

fonte: [Python Wiki](https://wiki.python.org/moin/KeyError)